### PR TITLE
[Additional Function] Remove candles method is introduced

### DIFF
--- a/timeseries/time_series.go
+++ b/timeseries/time_series.go
@@ -35,6 +35,38 @@ func (ts *TimeSeries) AddCandle(c *Candle) error {
 	return ErrUnexpectedTime
 }
 
+// RemoveCandles remove the candle from series
+// [startIndex] is mandatory
+// [endIndex] is optional
+// returns a new timeseries object
+func (ts *TimeSeries) RemoveCandles(startIndex int, endIndex *int) (*TimeSeries, error) {
+	if ts.Length() == 0 {
+		return nil, fmt.Errorf("timeseries cannot be empty")
+	}
+
+	if startIndex < 0 {
+		return nil, fmt.Errorf("startIndex cannot be negative")
+	}
+
+	if endIndex != nil && startIndex >= *endIndex {
+		return nil, fmt.Errorf("endIndex should be greater than startIndex")
+	}
+
+	if endIndex != nil && len(ts.candles) < *endIndex {
+		return nil, fmt.Errorf("endIndex should be less than candle size")
+	}
+
+	newTs := *ts
+
+	if endIndex == nil {
+		newTs.candles = newTs.candles[startIndex:]
+	} else {
+		newTs.candles = newTs.candles[startIndex:*endIndex]
+	}
+
+	return &newTs, nil
+}
+
 // LastCandle returns last candle in series
 func (ts *TimeSeries) LastCandle() *Candle {
 	if len(ts.candles) > 0 {

--- a/timeseries/time_series.go
+++ b/timeseries/time_series.go
@@ -37,8 +37,8 @@ func (ts *TimeSeries) AddCandle(c *Candle) error {
 
 // Trim returns selected section of candles from series
 // [startIndex] is mandatory
-// [endIndex] is optional
-func (ts *TimeSeries) Trim(startIndex int, endIndex *int) (*TimeSeries, error) {
+// [endIndex] is optional. If would not be in use, assign it as [endIndex=0]
+func (ts *TimeSeries) Trim(startIndex int, endIndex int) (*TimeSeries, error) {
 	if ts.Length() == 0 {
 		return nil, fmt.Errorf("timeseries cannot be empty")
 	}
@@ -47,21 +47,25 @@ func (ts *TimeSeries) Trim(startIndex int, endIndex *int) (*TimeSeries, error) {
 		return nil, fmt.Errorf("startIndex cannot be negative")
 	}
 
-	if endIndex != nil && startIndex >= *endIndex {
+	if endIndex < 0 {
+		return nil, fmt.Errorf("endIndex cannot be negative")
+	}
+
+	if endIndex != 0 && endIndex == startIndex {
 		return nil, fmt.Errorf("endIndex should be greater than startIndex")
 	}
 
-	if endIndex != nil && len(ts.candles) < *endIndex {
-		return nil, fmt.Errorf("endIndex should be less than candle size")
+	if len(ts.candles) < endIndex {
+		return nil, fmt.Errorf("endIndex should be less than equal to candle size")
 	}
 
 	newTs := *ts
 
-	if endIndex == nil {
-		newTs.candles = newTs.candles[startIndex:]
-	} else {
-		newTs.candles = newTs.candles[startIndex:*endIndex]
+	if endIndex == 0 {
+		endIndex = ts.Length()
 	}
+
+	newTs.candles = newTs.candles[startIndex:endIndex]
 
 	return &newTs, nil
 }

--- a/timeseries/time_series.go
+++ b/timeseries/time_series.go
@@ -35,11 +35,10 @@ func (ts *TimeSeries) AddCandle(c *Candle) error {
 	return ErrUnexpectedTime
 }
 
-// RemoveCandles remove the candle from series
+// Trim returns selected section of candles from series
 // [startIndex] is mandatory
 // [endIndex] is optional
-// returns a new timeseries object
-func (ts *TimeSeries) RemoveCandles(startIndex int, endIndex *int) (*TimeSeries, error) {
+func (ts *TimeSeries) Trim(startIndex int, endIndex *int) (*TimeSeries, error) {
 	if ts.Length() == 0 {
 		return nil, fmt.Errorf("timeseries cannot be empty")
 	}

--- a/timeseries/time_series_test.go
+++ b/timeseries/time_series_test.go
@@ -61,17 +61,17 @@ func TestTimeSeries_AddCandle(t *testing.T) {
 	})
 }
 
-func TestTimeSeries_RemoveCandles(t *testing.T) {
+func TestTimeSeries_Trim(t *testing.T) {
 	timeSeries := New()
 
 	t.Run("candle=nil", func(t *testing.T) {
-		_, err := timeSeries.RemoveCandles(0, nil)
+		_, err := timeSeries.Trim(0, nil)
 		assert.EqualError(t, err, "timeseries cannot be empty")
 	})
 
 	t.Run("startIndex=negative", func(t *testing.T) {
 		err := timeSeries.AddCandle(createTestCandle())
-		_, err1 := timeSeries.RemoveCandles(-1, nil)
+		_, err1 := timeSeries.Trim(-1, nil)
 
 		assert.Nil(t, err)
 		assert.EqualError(t, err1, "startIndex cannot be negative")
@@ -79,14 +79,14 @@ func TestTimeSeries_RemoveCandles(t *testing.T) {
 
 	t.Run("endIndex=cannot_bigger_than_startIndex", func(t *testing.T) {
 		endIndex := -1
-		_, err1 := timeSeries.RemoveCandles(0, &endIndex)
+		_, err1 := timeSeries.Trim(0, &endIndex)
 
 		assert.EqualError(t, err1, "endIndex should be greater than startIndex")
 	})
 
 	t.Run("endIndex=cannot_bigger_than_timeseries_length", func(t *testing.T) {
 		endIndex := 2
-		_, err1 := timeSeries.RemoveCandles(0, &endIndex)
+		_, err1 := timeSeries.Trim(0, &endIndex)
 
 		assert.EqualError(t, err1, "endIndex should be less than candle size")
 	})
@@ -98,7 +98,7 @@ func TestTimeSeries_RemoveCandles(t *testing.T) {
 		err := timeSeries.AddCandle(candle)
 
 		assert.Nil(t, err)
-		newTs, _ := timeSeries.RemoveCandles(1, nil)
+		newTs, _ := timeSeries.Trim(1, nil)
 
 		assert.Greater(t, timeSeries.Length(), newTs.Length())
 	})
@@ -117,7 +117,7 @@ func TestTimeSeries_RemoveCandles(t *testing.T) {
 		assert.Nil(t, err1)
 		assert.Nil(t, err2)
 
-		newTs, _ := timeSeries.RemoveCandles(2, &endIndex)
+		newTs, _ := timeSeries.Trim(2, &endIndex)
 
 		assert.Greater(t, timeSeries.Length(), newTs.Length())
 	})

--- a/timeseries/time_series_test.go
+++ b/timeseries/time_series_test.go
@@ -65,30 +65,37 @@ func TestTimeSeries_Trim(t *testing.T) {
 	timeSeries := New()
 
 	t.Run("candle=nil", func(t *testing.T) {
-		_, err := timeSeries.Trim(0, nil)
+		_, err := timeSeries.Trim(0, 0)
 		assert.EqualError(t, err, "timeseries cannot be empty")
 	})
 
 	t.Run("startIndex=negative", func(t *testing.T) {
 		err := timeSeries.AddCandle(createTestCandle())
-		_, err1 := timeSeries.Trim(-1, nil)
+		_, err1 := timeSeries.Trim(-1, 0)
 
 		assert.Nil(t, err)
 		assert.EqualError(t, err1, "startIndex cannot be negative")
 	})
 
-	t.Run("endIndex=cannot_bigger_than_startIndex", func(t *testing.T) {
+	t.Run("endIndex=negative", func(t *testing.T) {
 		endIndex := -1
-		_, err1 := timeSeries.Trim(0, &endIndex)
+		_, err1 := timeSeries.Trim(0, endIndex)
+
+		assert.EqualError(t, err1, "endIndex cannot be negative")
+	})
+
+	t.Run("endIndex=negative", func(t *testing.T) {
+		endIndex := 1
+		_, err1 := timeSeries.Trim(1, endIndex)
 
 		assert.EqualError(t, err1, "endIndex should be greater than startIndex")
 	})
 
 	t.Run("endIndex=cannot_bigger_than_timeseries_length", func(t *testing.T) {
 		endIndex := 2
-		_, err1 := timeSeries.Trim(0, &endIndex)
+		_, err1 := timeSeries.Trim(0, endIndex)
 
-		assert.EqualError(t, err1, "endIndex should be less than candle size")
+		assert.EqualError(t, err1, "endIndex should be less than equal to candle size")
 	})
 
 	t.Run("startIndex=single new ts should return", func(t *testing.T) {
@@ -98,7 +105,7 @@ func TestTimeSeries_Trim(t *testing.T) {
 		err := timeSeries.AddCandle(candle)
 
 		assert.Nil(t, err)
-		newTs, _ := timeSeries.Trim(1, nil)
+		newTs, _ := timeSeries.Trim(1, 0)
 
 		assert.Greater(t, timeSeries.Length(), newTs.Length())
 	})
@@ -117,7 +124,7 @@ func TestTimeSeries_Trim(t *testing.T) {
 		assert.Nil(t, err1)
 		assert.Nil(t, err2)
 
-		newTs, _ := timeSeries.Trim(2, &endIndex)
+		newTs, _ := timeSeries.Trim(2, endIndex)
 
 		assert.Greater(t, timeSeries.Length(), newTs.Length())
 	})

--- a/timeseries/time_series_test.go
+++ b/timeseries/time_series_test.go
@@ -61,6 +61,68 @@ func TestTimeSeries_AddCandle(t *testing.T) {
 	})
 }
 
+func TestTimeSeries_RemoveCandles(t *testing.T) {
+	timeSeries := New()
+
+	t.Run("candle=nil", func(t *testing.T) {
+		_, err := timeSeries.RemoveCandles(0, nil)
+		assert.EqualError(t, err, "timeseries cannot be empty")
+	})
+
+	t.Run("startIndex=negative", func(t *testing.T) {
+		err := timeSeries.AddCandle(createTestCandle())
+		_, err1 := timeSeries.RemoveCandles(-1, nil)
+
+		assert.Nil(t, err)
+		assert.EqualError(t, err1, "startIndex cannot be negative")
+	})
+
+	t.Run("endIndex=cannot_bigger_than_startIndex", func(t *testing.T) {
+		endIndex := -1
+		_, err1 := timeSeries.RemoveCandles(0, &endIndex)
+
+		assert.EqualError(t, err1, "endIndex should be greater than startIndex")
+	})
+
+	t.Run("endIndex=cannot_bigger_than_timeseries_length", func(t *testing.T) {
+		endIndex := 2
+		_, err1 := timeSeries.RemoveCandles(0, &endIndex)
+
+		assert.EqualError(t, err1, "endIndex should be less than candle size")
+	})
+
+	t.Run("startIndex=single new ts should return", func(t *testing.T) {
+		candle := createTestCandle()
+		candle.Time = time.Unix(2, 0)
+
+		err := timeSeries.AddCandle(candle)
+
+		assert.Nil(t, err)
+		newTs, _ := timeSeries.RemoveCandles(1, nil)
+
+		assert.Greater(t, timeSeries.Length(), newTs.Length())
+	})
+
+	t.Run("startIndex&endIndex=single new ts should return", func(t *testing.T) {
+		endIndex := 3
+
+		candle1 := createTestCandle()
+		candle1.Time = time.Unix(3, 0)
+		candle2 := createTestCandle()
+		candle2.Time = time.Unix(4, 0)
+
+		err1 := timeSeries.AddCandle(candle1)
+		err2 := timeSeries.AddCandle(candle2)
+
+		assert.Nil(t, err1)
+		assert.Nil(t, err2)
+
+		newTs, _ := timeSeries.RemoveCandles(2, &endIndex)
+
+		assert.Greater(t, timeSeries.Length(), newTs.Length())
+	})
+}
+
 func TestTimeSeries_LastCandle(t *testing.T) {
 	t.Run("LastCandle=nil", func(t *testing.T) {
 		series := New()


### PR DESCRIPTION
- Add `RemoveCandles` is introduced due to:
  - To calculate different ema/sma using with the based on created `TimeSeries` (example: ema15/ema20)
  - It helps that it returns a newly created `TimeSeries` object without requiring a loop.